### PR TITLE
Fix: 'inflateValidate' is only available on macOS 10.13 or newer

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -423,7 +423,8 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
       }
 
 #if ZLIB_VERNUM >= 0x1290 && \
-   defined(PNG_SET_OPTION_SUPPORTED) && defined(PNG_IGNORE_ADLER32)
+   defined(PNG_SET_OPTION_SUPPORTED) && defined(PNG_IGNORE_ADLER32) && \
+   !(defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED < 101300)
       if (((png_ptr->options >> PNG_IGNORE_ADLER32) & 3) == PNG_OPTION_ON)
          /* Turn off validation of the ADLER32 checksum in IDAT chunks */
          ret = inflateValidate(&png_ptr->zstream, 0);


### PR DESCRIPTION
The warning occurs when compiling the latest wxWidgets 3.1.1 on macOS and will cause the final application code to crash if run on macOS < 10.13.
The patch fixes the issue, following this one:
https://git.libreofficechina.org/libreoffice/core/src/8d2a287da3abb0576512406227d0a3acd602123e/external/libpng/libpng-osx.patch.1