### PR TITLE
Check for availability of zlib's inflateValidate on iOS and macOS

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -24,6 +24,7 @@
      defined(PNG_SET_OPTION_SUPPORTED) && defined(PNG_IGNORE_ADLER32)
 #     if defined(__APPLE__) && defined(__MACH__)
          /* Determine whether inflateValidate is available by checking:
+          * - for static zlib linking (best, but flaky and unreliable detection)
           * - at run-time by OS version (best with sys zlib usage)
           * - at compile-time by minimal supported OS version
           */
@@ -37,7 +38,16 @@
           * since 1.0 (10.3 SDK).
           */
 #        include <AvailabilityMacros.h>
-#        if defined(__clang__) && __has_builtin(__builtin_available)
+#        ifdef inflateValidate
+            /* Without this (empty) check usage of inflateValidate is driven
+             * only by OS version while zlib with inflateValidate could be
+             * linked statically.
+             * If the system's zlib is being used inflateValidate is not a
+             * macro so by checking if inflateValidate is a macro the cases
+             * where zlib is compiled with a prefix are at least handled and
+             * inflateValidate can then be used regardless of OS version.
+             */
+#        elif defined(__clang__) && __has_builtin(__builtin_available)
             /* Check at run-time for availability by OS version. */
 #           define PNG_USE_ZLIB_INFLATE_VALIDATE 2
 #        elif defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
@@ -52,7 +62,7 @@
                /* Don't use if targeting pre-macOS 10.13. */
 #              define PNG_USE_ZLIB_INFLATE_VALIDATE 0
 #           endif
-#        endif
+#        endif /* inflateValidate */
 #     endif /* __APPLE__ && __MACH__ */
 #  else
 #     define PNG_USE_ZLIB_INFLATE_VALIDATE 0

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -27,16 +27,27 @@
           * minimal supported OS version.
           */
 
-         /* For MAC_OS_X_VERSION_MIN_REQUIRED.
+         /* For TARGET_OS_IPHONE / TARGET_OS_MAC */
+#        include <TargetConditionals.h>
+
+         /* For IPHONE_OS_VERSION_MIN_REQUIRED / MAC_OS_X_VERSION_MIN_REQUIRED.
           * Not using the preferred <Availability.h> because it was introduced
           * during the 10.5 SDK while this header has been available with Xcode
           * since 1.0 (10.3 SDK).
           */
 #        include <AvailabilityMacros.h>
-#        if defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
-           MAC_OS_X_VERSION_MIN_REQUIRED < 101300
-            /* Don't use if targeting pre-macOS 10.13. */
-#           define PNG_USE_ZLIB_INFLATE_VALIDATE 0
+#        if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#           if defined(IPHONE_OS_VERSION_MIN_REQUIRED) && \
+              IPHONE_OS_VERSION_MIN_REQUIRED < 110000
+               /* Don't use if targeting pre-iOS 11.0. */
+#              define PNG_USE_ZLIB_INFLATE_VALIDATE 0
+#           endif
+#        elif defined(TARGET_OS_MAC) && TARGET_OS_MAC
+#           if defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
+              MAC_OS_X_VERSION_MIN_REQUIRED < 101300
+               /* Don't use if targeting pre-macOS 10.13. */
+#              define PNG_USE_ZLIB_INFLATE_VALIDATE 0
+#           endif
 #        endif
 #     endif /* __APPLE__ && __MACH__ */
 #  else

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -22,14 +22,23 @@
    /* Check if zlib's inflateValidate can be used. */
 #  if ZLIB_VERNUM >= 0x1290 && \
      defined(PNG_SET_OPTION_SUPPORTED) && defined(PNG_IGNORE_ADLER32)
-      /* Determine at compile-time whether inflateValidate is available by
-       * minimal supported OS version.
-       */
-#     if defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
-        MAC_OS_X_VERSION_MIN_REQUIRED < 101300
-         /* Don't use if targeting pre-macOS 10.13. */
-#        define PNG_USE_ZLIB_INFLATE_VALIDATE 0
-#     endif
+#     if defined(__APPLE__) && defined(__MACH__)
+         /* Determine at compile-time whether inflateValidate is available by
+          * minimal supported OS version.
+          */
+
+         /* For MAC_OS_X_VERSION_MIN_REQUIRED.
+          * Not using the preferred <Availability.h> because it was introduced
+          * during the 10.5 SDK while this header has been available with Xcode
+          * since 1.0 (10.3 SDK).
+          */
+#        include <AvailabilityMacros.h>
+#        if defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
+           MAC_OS_X_VERSION_MIN_REQUIRED < 101300
+            /* Don't use if targeting pre-macOS 10.13. */
+#           define PNG_USE_ZLIB_INFLATE_VALIDATE 0
+#        endif
+#     endif /* __APPLE__ && __MACH__ */
 #  else
 #     define PNG_USE_ZLIB_INFLATE_VALIDATE 0
 #  endif /* ZLIB_VERNUM && PNG_SET_OPTION_SUPPORTED && PNG_IGNORE_ADLER32 */


### PR DESCRIPTION
For new enough versions of zlib its `inflateValidate` could be called which is a problem if using a system's zlib and targeting systems prior to iOS 11.0 or macOS 13.0 as those don't have `inflateValidate`. There are also warnings about that situation, this one being for macOS:

```
warning: 'inflateValidate' is only available on macOS 10.13 or newer [-Wunguarded-availability-new]
```

(reproducible by configuring wx with `--with-libpng=builtin --with-zlib=sys`, using a 10.13+ SDK, targeting pre-10.13 which wx does)

This PR tries to remedy that by checking for static linking usage first (and mostly, b825c1723d, failing currently except with e.g. wx' builtin zlib), otherwise at run-time if possible, and finally at compile-time based on deployment targets.

The warning is based on having included a system's `zlib.h` (with decorated function declarations for availibility) and doesn't occur when including a user's `zlib.h`. In the latter case `inflateValidate` should always be allowed to be used however I haven't figured out a way to detect a difference (such as the decorators) between using a sys and user `zlib.h` . So  `inflateValidate` on iOS/macOS is now not used under certain conditions, even though it is available.

See also https://github.com/wxWidgets/libpng/pull/1 and https://github.com/glennrp/libpng/issues/187.